### PR TITLE
use ConstrainedBox so event list date circles = same size

### DIFF
--- a/lib/src/eventsView.dart
+++ b/lib/src/eventsView.dart
@@ -23,23 +23,27 @@ class EventsView extends StatelessWidget {
   final String dateField;
   final ThemeData theme;
 
-  Widget dateBadge(day) => Container(
-        margin: EdgeInsets.all(8.0),
-        padding: EdgeInsets.all(16.0),
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          color: theme.accentColor,
-        ),
-        child: Column(
-          children: <Widget>[
-            Text(
-              day.toString(),
-              textAlign: TextAlign.center,
-              style: theme.accentTextTheme.title,
-            ),
-          ],
+  Widget dateBadge(day) => ConstrainedBox(
+        constraints: new BoxConstraints(minWidth: 75.0),
+        child: new Container(
+          margin: EdgeInsets.all(8.0),
+          padding: EdgeInsets.all(16.0),
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: theme.accentColor,
+          ),
+          child: Column(
+            children: <Widget>[
+              Text(
+                day.toString(),
+                textAlign: TextAlign.center,
+                style: theme.accentTextTheme.title,
+              ),
+            ],
+          ),
         ),
       );
+
 
   String timeString(event) {
     final date = DateTime.parse(event[dateField]);


### PR DESCRIPTION
Wrapped the `Container` in a `ConstrainedBox` class so event date circles in list view are the same size.

![screenshot 2018-10-29 10 39 05](https://user-images.githubusercontent.com/2086896/47661451-111c9380-db67-11e8-8393-d5ea4ab3fcb5.png)
